### PR TITLE
[Feat] #21 - 엔티티 내부 유효성 검증 로직에서 CustomException을 사용하도록 변경

### DIFF
--- a/src/main/java/com/arabook/arabook/common/exception/book/BookException.java
+++ b/src/main/java/com/arabook/arabook/common/exception/book/BookException.java
@@ -1,0 +1,10 @@
+package com.arabook.arabook.common.exception.book;
+
+import com.arabook.arabook.common.exception.common.ClientException;
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+public class BookException extends ClientException {
+	public BookException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/src/main/java/com/arabook/arabook/common/exception/book/BookExceptionType.java
+++ b/src/main/java/com/arabook/arabook/common/exception/book/BookExceptionType.java
@@ -1,0 +1,26 @@
+package com.arabook.arabook.common.exception.book;
+
+import org.springframework.http.HttpStatus;
+
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum BookExceptionType implements ExceptionType {
+	INVALID_BOOK_ISBN(HttpStatus.BAD_REQUEST, "ISBN은 13자리여야 합니다");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus status() {
+		return this.status;
+	}
+
+	@Override
+	public String message() {
+		return this.message;
+	}
+}

--- a/src/main/java/com/arabook/arabook/common/exception/review/ReviewException.java
+++ b/src/main/java/com/arabook/arabook/common/exception/review/ReviewException.java
@@ -1,0 +1,10 @@
+package com.arabook.arabook.common.exception.review;
+
+import com.arabook.arabook.common.exception.common.ClientException;
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+public class ReviewException extends ClientException {
+	public ReviewException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/src/main/java/com/arabook/arabook/common/exception/review/ReviewExceptionType.java
+++ b/src/main/java/com/arabook/arabook/common/exception/review/ReviewExceptionType.java
@@ -1,0 +1,27 @@
+package com.arabook.arabook.common.exception.review;
+
+import org.springframework.http.HttpStatus;
+
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ReviewExceptionType implements ExceptionType {
+	INVALID_READ_START_DATE(HttpStatus.BAD_REQUEST, "책 읽기 시작 날짜가 올바르지 않습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus status() {
+		return this.status;
+	}
+
+	@Override
+	public String message() {
+		return this.message;
+	}
+}

--- a/src/main/java/com/arabook/arabook/storage/domain/book/entity/Book.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/book/entity/Book.java
@@ -1,5 +1,7 @@
 package com.arabook.arabook.storage.domain.book.entity;
 
+import static com.arabook.arabook.common.exception.book.BookExceptionType.*;
+
 import java.time.Year;
 
 import jakarta.persistence.Column;
@@ -9,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+
+import com.arabook.arabook.common.exception.book.BookException;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -59,9 +63,8 @@ public class Book {
 	}
 
 	private String validateIsbn(String isbn) {
-		// TODO:: ISBN 유효성 검사에 대한 예외 customException으로 변경
 		if (isbn.length() != 13) {
-			throw new IllegalArgumentException("ISBN은 13자리여야 합니다.");
+			throw new BookException(INVALID_BOOK_ISBN);
 		}
 		return isbn;
 	}

--- a/src/main/java/com/arabook/arabook/storage/domain/review/entity/Review.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/review/entity/Review.java
@@ -1,5 +1,7 @@
 package com.arabook.arabook.storage.domain.review.entity;
 
+import static com.arabook.arabook.common.exception.review.ReviewExceptionType.*;
+
 import java.time.LocalDate;
 
 import jakarta.persistence.Entity;
@@ -14,6 +16,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
+import com.arabook.arabook.common.exception.review.ReviewException;
 import com.arabook.arabook.storage.domain.book.entity.Book;
 import com.arabook.arabook.storage.domain.common.entity.BaseTimeEntity;
 import com.arabook.arabook.storage.domain.member.entity.Member;
@@ -66,8 +69,7 @@ public class Review extends BaseTimeEntity {
 
 	private void validateReadDate(LocalDate readStartDate, LocalDate readEndDate) {
 		if (readStartDate.isAfter(readEndDate)) {
-			// TODO: 서비스 custom exception으로 변경
-			throw new IllegalArgumentException("읽기 시작한 날짜가 다 읽은 날짜보다 늦을 수 없습니다.");
+			throw new ReviewException(INVALID_READ_START_DATE);
 		}
 	}
 }


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 엔티티 내부 유효성 검증 로직에서 각자의 CustomException을 사용하도록 변경했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- X 

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
- X

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #21 
