### PR TITLE
[Feat] #25 - 도서 상세조회 API 구현

### DIFF
--- a/src/main/java/com/arabook/arabook/api/book/controller/BookController.java
+++ b/src/main/java/com/arabook/arabook/api/book/controller/BookController.java
@@ -4,10 +4,12 @@ import static com.arabook.arabook.common.success.book.BookSuccessType.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.arabook.arabook.api.book.controller.dto.response.BookDetailResponse;
 import com.arabook.arabook.api.book.controller.dto.response.BooksResponse;
 import com.arabook.arabook.api.book.service.BookService;
 import com.arabook.arabook.common.response.ResponseTemplate;
@@ -17,9 +19,18 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/books")
 @RequiredArgsConstructor
-public class BookController {
+public class BookController implements BookApi {
   private final BookService bookService;
 
+  @Override
+  @GetMapping("/{bookId}")
+  public ResponseEntity<ResponseTemplate<BookDetailResponse>> getBookDetail(
+      @PathVariable("bookId") final Long bookId) {
+    BookDetailResponse response = bookService.getBookDetail(bookId);
+    return ResponseEntity.ok(ResponseTemplate.success(GET_BOOK_DETAIL, response));
+  }
+
+  @Override
   @GetMapping("/search")
   public ResponseEntity<ResponseTemplate<BooksResponse>> getBooksBySearch(
       @RequestParam("keyword") final String keyword) {

--- a/src/main/java/com/arabook/arabook/api/book/controller/dto/response/BookDetailResponse.java
+++ b/src/main/java/com/arabook/arabook/api/book/controller/dto/response/BookDetailResponse.java
@@ -1,6 +1,9 @@
 package com.arabook.arabook.api.book.controller.dto.response;
 
+import java.time.Year;
 import java.util.List;
+
+import com.arabook.arabook.storage.domain.book.entity.Book;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -11,7 +14,23 @@ public record BookDetailResponse(
     @Schema(description = "책 제목", example = "퀸의 대각선") String title,
     @Schema(description = "책 작가", example = "베르나르베르베르") String author,
     @Schema(description = "책 출판사", example = "출판사") String publisher,
-    @Schema(description = "책 출판일", example = "2021-01-01") String publicationDate,
+    @Schema(description = "책 출판년도", example = "2021") Year publicationYear,
     @Schema(description = "책 설명", example = "책 설명") String description,
     @Schema(description = "책 카테고리") List<CategoryResponse> categories,
-    @Schema(description = "책 해시태그") List<HashTagResponse> hashtags) {}
+    @Schema(description = "책 해시태그") List<HashTagResponse> hashtags) {
+  public static BookDetailResponse of(
+      final Book book,
+      final List<CategoryResponse> categories,
+      final List<HashTagResponse> hashtags) {
+    return new BookDetailResponse(
+        book.getBookId(),
+        book.getCoverUrl(),
+        book.getTitle(),
+        book.getAuthor(),
+        book.getPublisher(),
+        book.getPublishYear(),
+        book.getDescription(),
+        categories,
+        hashtags);
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/book/service/BookService.java
+++ b/src/main/java/com/arabook/arabook/api/book/service/BookService.java
@@ -1,7 +1,10 @@
 package com.arabook.arabook.api.book.service;
 
+import com.arabook.arabook.api.book.controller.dto.response.BookDetailResponse;
 import com.arabook.arabook.api.book.controller.dto.response.BooksResponse;
 
 public interface BookService {
   BooksResponse getBooksBySearch(String keyword);
+
+  BookDetailResponse getBookDetail(Long bookId);
 }

--- a/src/main/java/com/arabook/arabook/api/book/service/BookServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/api/book/service/BookServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.arabook.arabook.api.book.controller.dto.response.BookDetailResponse;
 import com.arabook.arabook.api.book.controller.dto.response.BookResponse;
 import com.arabook.arabook.api.book.controller.dto.response.BooksResponse;
 import com.arabook.arabook.storage.domain.book.repository.BookRepository;
@@ -21,5 +22,10 @@ public class BookServiceImpl implements BookService {
   public BooksResponse getBooksBySearch(final String keyword) {
     final List<BookResponse> bookResponses = bookRepository.findBooksBySearch(keyword);
     return BooksResponse.of(bookResponses.size(), bookResponses);
+  }
+
+  @Override
+  public BookDetailResponse getBookDetail(final Long bookId) {
+    return bookRepository.findBookDetail(bookId);
   }
 }

--- a/src/main/java/com/arabook/arabook/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/arabook/arabook/api/global/config/SwaggerConfig.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
     },
     servers = {
       @Server(url = "http://localhost:8080", description = "local server"),
+      @Server(url = "https://api.arabook.p-e.kr", description = "dev server")
     })
 @SecuritySchemes({
   @SecurityScheme(

--- a/src/main/java/com/arabook/arabook/common/exception/book/BookExceptionType.java
+++ b/src/main/java/com/arabook/arabook/common/exception/book/BookExceptionType.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum BookExceptionType implements ExceptionType {
-  INVALID_BOOK_ISBN(HttpStatus.BAD_REQUEST, "ISBN은 13자리여야 합니다");
+  INVALID_BOOK_ISBN(HttpStatus.BAD_REQUEST, "ISBN은 13자리여야 합니다"),
+  BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "책을 찾을 수 없습니다");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/arabook/arabook/common/success/book/BookSuccessType.java
+++ b/src/main/java/com/arabook/arabook/common/success/book/BookSuccessType.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum BookSuccessType implements SuccessType {
   // 200 OK
-  GET_BOOKS_BY_SEARCH(HttpStatus.OK, "검색 결과를 성공적으로 조회하였습니다");
+  GET_BOOKS_BY_SEARCH(HttpStatus.OK, "검색 결과를 조회하였습니다"),
+  GET_BOOK_DETAIL(HttpStatus.OK, "책 상세 정보를 조회하였습니다");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/arabook/arabook/storage/domain/book/repository/BookCustomRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/book/repository/BookCustomRepository.java
@@ -2,8 +2,11 @@ package com.arabook.arabook.storage.domain.book.repository;
 
 import java.util.List;
 
+import com.arabook.arabook.api.book.controller.dto.response.BookDetailResponse;
 import com.arabook.arabook.api.book.controller.dto.response.BookResponse;
 
 public interface BookCustomRepository {
   List<BookResponse> findBooksBySearch(String keyword);
+
+  BookDetailResponse findBookDetail(Long bookId);
 }


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 도서 상세조회 API를 구현했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- swagger config에 dev server url도 추가했습니다!

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :---------------: | :----------: |
| 상세보기 <br>조회<br>성공 시 | <img src = "https://github.com/user-attachments/assets/00964066-19e7-4f6d-b6df-d6b7e88776e1" width ="700">|
| 존재하지<br> 않는 책 id<br>요청 시 | <img src = "https://github.com/user-attachments/assets/b84ebf92-8940-40b7-bf84-2784cea227d7" width ="700">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #25
