### PR TITLE
[Feat] #32 - 온보딩 API 구현

### DIFF
--- a/src/main/java/com/arabook/arabook/api/global/config/WebConfig.java
+++ b/src/main/java/com/arabook/arabook/api/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.arabook.arabook.api.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.arabook.arabook.api.global.security.AuthMemberArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new AuthMemberArgumentResolver());
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/global/security/AuthMember.java
+++ b/src/main/java/com/arabook/arabook/api/global/security/AuthMember.java
@@ -1,0 +1,10 @@
+package com.arabook.arabook.api.global.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthMember {}

--- a/src/main/java/com/arabook/arabook/api/global/security/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/arabook/arabook/api/global/security/AuthMemberArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.arabook.arabook.api.global.security;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    boolean hasAuthMemberAnnotation = parameter.getParameterAnnotation(AuthMember.class) != null;
+    boolean isMemberIdString = parameter.getParameterType().equals(Long.class);
+    return hasAuthMemberAnnotation && isMemberIdString;
+  }
+
+  @Override
+  public Object resolveArgument(
+      MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    boolean isNotAuthenticatedMember = authentication == null || !authentication.isAuthenticated();
+    if (isNotAuthenticatedMember) {
+      return null;
+    }
+    return Long.valueOf((String) authentication.getPrincipal());
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/member/controller/MemberApi.java
+++ b/src/main/java/com/arabook/arabook/api/member/controller/MemberApi.java
@@ -1,0 +1,43 @@
+package com.arabook.arabook.api.member.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import com.arabook.arabook.api.member.controller.dto.request.MemberOnboardingRequest;
+import com.arabook.arabook.common.response.ResponseTemplate;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "member", description = "회원과 관련된 API")
+public interface MemberApi {
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "온보딩을 완료했습니다.",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            example =
+                                "{ \"code\": 204, \"message\": \"온보딩을 완료했습니다.\", \"data\": \"No Data\" }"))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효한 카테고리를 찾을 수 없습니다",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            example =
+                                "{ \"code\": 400, \"message\": \"유효한 카테고리를 찾을 수 없습니다.\", \"data\": \"No Data\" }")))
+      })
+  @Operation(summary = "온보딩: 회원가입 이후 온보딩 요청", description = "온보딩 정보를 받습니다")
+  ResponseEntity<ResponseTemplate> onboarding(
+      @Schema() MemberOnboardingRequest request, @Schema(hidden = true) Long memberId);
+}

--- a/src/main/java/com/arabook/arabook/api/member/controller/MemberApi.java
+++ b/src/main/java/com/arabook/arabook/api/member/controller/MemberApi.java
@@ -39,5 +39,5 @@ public interface MemberApi {
       })
   @Operation(summary = "온보딩: 회원가입 이후 온보딩 요청", description = "온보딩 정보를 받습니다")
   ResponseEntity<ResponseTemplate> onboarding(
-      @Schema() MemberOnboardingRequest request, @Schema(hidden = true) Long memberId);
+      MemberOnboardingRequest request, @Schema(hidden = true) Long memberId);
 }

--- a/src/main/java/com/arabook/arabook/api/member/controller/MemberController.java
+++ b/src/main/java/com/arabook/arabook/api/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.arabook.arabook.api.member.controller;
+
+import static com.arabook.arabook.common.success.member.MemberSuccessType.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.arabook.arabook.api.global.security.AuthMember;
+import com.arabook.arabook.api.member.controller.dto.request.MemberOnboardingRequest;
+import com.arabook.arabook.api.member.service.MemberServiceImpl;
+import com.arabook.arabook.common.response.ResponseTemplate;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class MemberController implements MemberApi {
+  private final MemberServiceImpl memberService;
+
+  @Override
+  @PutMapping("/onboarding")
+  public ResponseEntity<ResponseTemplate> onboarding(
+      @RequestBody final MemberOnboardingRequest request, @AuthMember final Long memberId) {
+    memberService.onboarding(request, memberId);
+    return ResponseEntity.ok(ResponseTemplate.success(ONBOARDING_SUCCESS));
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/member/controller/dto/request/MemberOnboardingRequest.java
+++ b/src/main/java/com/arabook/arabook/api/member/controller/dto/request/MemberOnboardingRequest.java
@@ -1,0 +1,14 @@
+package com.arabook.arabook.api.member.controller.dto.request;
+
+import java.util.List;
+
+import com.arabook.arabook.storage.domain.member.entity.enums.Gender;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "MemberOnboardingRequest", description = "회원 온보딩 요청 DTO")
+public record MemberOnboardingRequest(
+    @Schema(description = "성별 (MAN, WOMAN, UNKNOWN", example = "WOMAN") Gender gender,
+    @Schema(description = "나이", example = "21") int age,
+    @Schema(description = "서버로부터 조회한 category id 리스트", example = "[1,2,3]")
+        List<Long> interestCategoryIds) {}

--- a/src/main/java/com/arabook/arabook/api/member/service/MemberCategorySelectionService.java
+++ b/src/main/java/com/arabook/arabook/api/member/service/MemberCategorySelectionService.java
@@ -1,0 +1,9 @@
+package com.arabook.arabook.api.member.service;
+
+import java.util.List;
+
+import com.arabook.arabook.storage.domain.member.entity.Member;
+
+public interface MemberCategorySelectionService {
+  void selectCategories(Member member, List<Long> categoryId);
+}

--- a/src/main/java/com/arabook/arabook/api/member/service/MemberCategorySelectionServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/api/member/service/MemberCategorySelectionServiceImpl.java
@@ -1,0 +1,52 @@
+package com.arabook.arabook.api.member.service;
+
+import static com.arabook.arabook.common.exception.category.CategoryExceptionType.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.arabook.arabook.common.exception.category.CategoryException;
+import com.arabook.arabook.storage.domain.category.entity.Category;
+import com.arabook.arabook.storage.domain.category.repository.CategoryRepository;
+import com.arabook.arabook.storage.domain.member.entity.Member;
+import com.arabook.arabook.storage.domain.member.entity.MemberCategorySelection;
+import com.arabook.arabook.storage.domain.member.repository.MemberCategorySelectionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberCategorySelectionServiceImpl implements MemberCategorySelectionService {
+  private final MemberCategorySelectionRepository memberCategorySelectionRepository;
+  private final CategoryRepository categoryRepository;
+
+  @Override
+  @Transactional
+  public void selectCategories(Member member, List<Long> categoryIds) {
+
+    memberCategorySelectionRepository.deleteAllByMember(member);
+
+    List<Category> categories = categoryRepository.findAllById(categoryIds);
+
+    if (categories.size() != categoryIds.size()) {
+      throw new CategoryException(INVALID_CATEGORY_ID);
+    }
+
+    List<MemberCategorySelection> memberCategorySelections =
+        categories.stream()
+            .map(
+                category -> {
+                  return MemberCategorySelection.builder()
+                      .member(member)
+                      .category(category)
+                      .build();
+                })
+            .collect(Collectors.toList());
+
+    memberCategorySelectionRepository.saveAll(memberCategorySelections);
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/member/service/MemberService.java
+++ b/src/main/java/com/arabook/arabook/api/member/service/MemberService.java
@@ -1,0 +1,7 @@
+package com.arabook.arabook.api.member.service;
+
+import com.arabook.arabook.api.member.controller.dto.request.MemberOnboardingRequest;
+
+public interface MemberService {
+  void onboarding(MemberOnboardingRequest request, Long memberId);
+}

--- a/src/main/java/com/arabook/arabook/api/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/api/member/service/MemberServiceImpl.java
@@ -1,0 +1,26 @@
+package com.arabook.arabook.api.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.arabook.arabook.api.member.controller.dto.request.MemberOnboardingRequest;
+import com.arabook.arabook.storage.domain.member.entity.Member;
+import com.arabook.arabook.storage.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberServiceImpl implements MemberService {
+  private final MemberRepository memberRepository;
+  private final MemberCategorySelectionService memberCategorySelectionSerivce;
+
+  @Override
+  @Transactional
+  public void onboarding(final MemberOnboardingRequest request, final Long memberId) {
+    Member member = memberRepository.findByMemberIdOrThrow(memberId);
+    member.updateOnboardingInfo(request.gender(), request.age());
+    memberCategorySelectionSerivce.selectCategories(member, request.interestCategoryIds());
+  }
+}

--- a/src/main/java/com/arabook/arabook/common/exception/category/CategoryException.java
+++ b/src/main/java/com/arabook/arabook/common/exception/category/CategoryException.java
@@ -1,0 +1,10 @@
+package com.arabook.arabook.common.exception.category;
+
+import com.arabook.arabook.common.exception.common.ClientException;
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+public class CategoryException extends ClientException {
+  public CategoryException(ExceptionType exceptionType) {
+    super(exceptionType);
+  }
+}

--- a/src/main/java/com/arabook/arabook/common/exception/category/CategoryExceptionType.java
+++ b/src/main/java/com/arabook/arabook/common/exception/category/CategoryExceptionType.java
@@ -1,0 +1,25 @@
+package com.arabook.arabook.common.exception.category;
+
+import org.springframework.http.HttpStatus;
+
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum CategoryExceptionType implements ExceptionType {
+  INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "유효한 카테고리를 찾을 수 없습니다");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public HttpStatus status() {
+    return this.status;
+  }
+
+  @Override
+  public String message() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/arabook/arabook/common/exception/member/MemberException.java
+++ b/src/main/java/com/arabook/arabook/common/exception/member/MemberException.java
@@ -1,0 +1,10 @@
+package com.arabook.arabook.common.exception.member;
+
+import com.arabook.arabook.common.exception.common.ClientException;
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+public class MemberException extends ClientException {
+  public MemberException(ExceptionType exceptionType) {
+    super(exceptionType);
+  }
+}

--- a/src/main/java/com/arabook/arabook/common/exception/member/MemberExceptionType.java
+++ b/src/main/java/com/arabook/arabook/common/exception/member/MemberExceptionType.java
@@ -1,0 +1,25 @@
+package com.arabook.arabook.common.exception.member;
+
+import org.springframework.http.HttpStatus;
+
+import com.arabook.arabook.common.exception.common.ExceptionType;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum MemberExceptionType implements ExceptionType {
+  NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public HttpStatus status() {
+    return this.status;
+  }
+
+  @Override
+  public String message() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/arabook/arabook/common/success/member/MemberSuccessType.java
+++ b/src/main/java/com/arabook/arabook/common/success/member/MemberSuccessType.java
@@ -1,0 +1,25 @@
+package com.arabook.arabook.common.success.member;
+
+import org.springframework.http.HttpStatus;
+
+import com.arabook.arabook.common.success.common.SuccessType;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum MemberSuccessType implements SuccessType {
+  ONBOARDING_SUCCESS(HttpStatus.OK, "온보딩을 완료했습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public HttpStatus status() {
+    return this.status;
+  }
+
+  @Override
+  public String message() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.arabook.arabook.storage.domain.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.arabook.arabook.storage.domain.category.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {}

--- a/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
@@ -60,4 +60,9 @@ public class Member extends BaseTimeEntity {
     this.age = 999;
     this.role = Role.GUEST;
   }
+
+  public void updateOnboardingInfo(final Gender gender, final int age) {
+    this.gender = gender;
+    this.age = age;
+  }
 }

--- a/src/main/java/com/arabook/arabook/storage/domain/member/repository/MemberCategorySelectionRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/member/repository/MemberCategorySelectionRepository.java
@@ -1,0 +1,11 @@
+package com.arabook.arabook.storage.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.arabook.arabook.storage.domain.member.entity.Member;
+import com.arabook.arabook.storage.domain.member.entity.MemberCategorySelection;
+
+public interface MemberCategorySelectionRepository
+    extends JpaRepository<MemberCategorySelection, Long> {
+  void deleteAllByMember(Member member);
+}

--- a/src/main/java/com/arabook/arabook/storage/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/member/repository/MemberRepository.java
@@ -1,0 +1,18 @@
+package com.arabook.arabook.storage.domain.member.repository;
+
+import static com.arabook.arabook.common.exception.member.MemberExceptionType.*;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.arabook.arabook.common.exception.member.MemberException;
+import com.arabook.arabook.storage.domain.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+  Optional<Member> findByMemberId(final Long memberId);
+
+  default Member findByMemberIdOrThrow(final Long memberId) {
+    return findByMemberId(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+  }
+}


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 온보딩 API를 구현했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- 서버에서 조회한 categoryId로 요청하지 않을 경우 400 에러가 발생합니다
- `@AuthMember` 어노테이션을 통해 memberId를 가져오는 로직을 구현했습니다

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 온보딩<br>성공 | <img src = "https://github.com/user-attachments/assets/2b20e7ad-3276-4f3a-bea1-ecc3afe23723" width ="700">|
| 유효하지<br>않은<br>카테고리 | <img src = "https://github.com/user-attachments/assets/976d431d-1241-4e7a-8083-983e8d8b5391" width ="700">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #32
