### PR TITLE
[Feat] #41 - 온보딩에서의 카테고리 조회 API 구현

### DIFF
--- a/src/main/java/com/arabook/arabook/api/book/controller/dto/response/AIRecommendBookResponse.java
+++ b/src/main/java/com/arabook/arabook/api/book/controller/dto/response/AIRecommendBookResponse.java
@@ -2,6 +2,8 @@ package com.arabook.arabook.api.book.controller.dto.response;
 
 import java.util.List;
 
+import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "AIRecommendBookResponse", description = "AI 추천 책 응답 DTO")

--- a/src/main/java/com/arabook/arabook/api/book/controller/dto/response/BookDetailResponse.java
+++ b/src/main/java/com/arabook/arabook/api/book/controller/dto/response/BookDetailResponse.java
@@ -3,6 +3,7 @@ package com.arabook.arabook.api.book.controller.dto.response;
 import java.time.Year;
 import java.util.List;
 
+import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
 import com.arabook.arabook.storage.domain.book.entity.Book;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/arabook/arabook/api/book/controller/dto/response/BookDetailResponse.java
+++ b/src/main/java/com/arabook/arabook/api/book/controller/dto/response/BookDetailResponse.java
@@ -4,6 +4,7 @@ import java.time.Year;
 import java.util.List;
 
 import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
+import com.arabook.arabook.api.hashtag.controller.dto.response.HashTagResponse;
 import com.arabook.arabook.storage.domain.book.entity.Book;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/arabook/arabook/api/book/controller/dto/response/CategoryResponse.java
+++ b/src/main/java/com/arabook/arabook/api/book/controller/dto/response/CategoryResponse.java
@@ -1,8 +1,0 @@
-package com.arabook.arabook.api.book.controller.dto.response;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-
-@Schema(name = "CategoryResponse", description = "책 카테고리 응답 DTO")
-public record CategoryResponse(
-    @Schema(description = "카테고리 id", example = "1") long categoryId,
-    @Schema(description = "카테고리 이름", example = "국내소설") String name) {}

--- a/src/main/java/com/arabook/arabook/api/category/controller/CategoryApi.java
+++ b/src/main/java/com/arabook/arabook/api/category/controller/CategoryApi.java
@@ -3,6 +3,7 @@ package com.arabook.arabook.api.category.controller;
 import org.springframework.http.ResponseEntity;
 
 import com.arabook.arabook.api.category.controller.dto.response.CategoriesResponse;
+import com.arabook.arabook.common.response.ResponseTemplate;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,5 +28,5 @@ public interface CategoryApi {
                                 "{\"code\": 200, \"message\": \"카테고리 조회에 성공했습니다\", \"data\": { \"totalCount\": 2, \"categories\": \"[{ \"categoryId\": 1, \"categoryName\": \"로맨스\" }, { \"categoryId\": 2, \"categoryName\": \"판타지\" }]\"}")))
       })
   @Operation(summary = "온보딩: 카테고리 리스트 조회", description = "카테고리를 조회합니다.")
-  ResponseEntity<CategoriesResponse> getCategories();
+  ResponseEntity<ResponseTemplate<CategoriesResponse>> getCategories();
 }

--- a/src/main/java/com/arabook/arabook/api/category/controller/CategoryApi.java
+++ b/src/main/java/com/arabook/arabook/api/category/controller/CategoryApi.java
@@ -1,0 +1,31 @@
+package com.arabook.arabook.api.category.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import com.arabook.arabook.api.category.controller.dto.response.CategoriesResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "category", description = "책의 카테고리와 관련된 API")
+public interface CategoryApi {
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "카테고리 조회에 성공했습니다.",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            example =
+                                "{\"code\": 200, \"message\": \"카테고리 조회에 성공했습니다\", \"data\": { \"totalCount\": 2, \"categories\": \"[{ \"categoryId\": 1, \"categoryName\": \"로맨스\" }, { \"categoryId\": 2, \"categoryName\": \"판타지\" }]\"}")))
+      })
+  @Operation(summary = "온보딩: 카테고리 리스트 조회", description = "카테고리를 조회합니다.")
+  ResponseEntity<CategoriesResponse> getCategories();
+}

--- a/src/main/java/com/arabook/arabook/api/category/controller/CategoryController.java
+++ b/src/main/java/com/arabook/arabook/api/category/controller/CategoryController.java
@@ -1,0 +1,28 @@
+package com.arabook.arabook.api.category.controller;
+
+import static com.arabook.arabook.common.success.category.CategorySuccessType.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.arabook.arabook.api.category.controller.dto.response.CategoriesResponse;
+import com.arabook.arabook.api.category.service.CategoryService;
+import com.arabook.arabook.common.response.ResponseTemplate;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+public class CategoryController implements CategoryApi {
+  private final CategoryService categoryService;
+
+  @Override
+  @GetMapping
+  public ResponseEntity<ResponseTemplate<CategoriesResponse>> getCategories() {
+    CategoriesResponse response = categoryService.getCategories();
+    return ResponseEntity.ok(ResponseTemplate.success(GET_CATEGORIES, response));
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/category/controller/dto/response/CategoriesResponse.java
+++ b/src/main/java/com/arabook/arabook/api/category/controller/dto/response/CategoriesResponse.java
@@ -1,0 +1,18 @@
+package com.arabook.arabook.api.category.controller.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CategoriesResponse", description = "카테고리 리스트 응답 DTO")
+public record CategoriesResponse(
+    @Schema(description = "조회된 카테고리의 수", example = "1") int totalCount,
+    @Schema(
+            description = "카테고리 목록",
+            example =
+                "[{ \"categoryId\": 1, \"categoryName\": \"로맨스\" }, { \"categoryId\": 2, \"categoryName\": \"판타지\" }]")
+        List<CategoryResponse> categories) {
+  public static CategoriesResponse of(int totalCount, List<CategoryResponse> categories) {
+    return new CategoriesResponse(totalCount, categories);
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/category/controller/dto/response/CategoryResponse.java
+++ b/src/main/java/com/arabook/arabook/api/category/controller/dto/response/CategoryResponse.java
@@ -1,0 +1,8 @@
+package com.arabook.arabook.api.category.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CategoryResponse", description = "카테고리 응답 DTO")
+public record CategoryResponse(
+    @Schema(description = "카테고리 id", example = "1") long categoryId,
+    @Schema(description = "카테고리명", example = "로맨스") String categoryName) {}

--- a/src/main/java/com/arabook/arabook/api/category/service/CategoryService.java
+++ b/src/main/java/com/arabook/arabook/api/category/service/CategoryService.java
@@ -1,0 +1,7 @@
+package com.arabook.arabook.api.category.service;
+
+import com.arabook.arabook.api.category.controller.dto.response.CategoriesResponse;
+
+public interface CategoryService {
+  CategoriesResponse getCategories();
+}

--- a/src/main/java/com/arabook/arabook/api/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/api/category/service/CategoryServiceImpl.java
@@ -1,0 +1,25 @@
+package com.arabook.arabook.api.category.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.arabook.arabook.api.category.controller.dto.response.CategoriesResponse;
+import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
+import com.arabook.arabook.storage.domain.category.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryServiceImpl implements CategoryService {
+  private final CategoryRepository categoryRepository;
+
+  @Override
+  public CategoriesResponse getCategories() {
+    List<CategoryResponse> categories = categoryRepository.findAllOrderByCategoryNameAsc();
+    return CategoriesResponse.of(categories.size(), categories);
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/hashtag/controller/dto/response/HashTagResponse.java
+++ b/src/main/java/com/arabook/arabook/api/hashtag/controller/dto/response/HashTagResponse.java
@@ -1,4 +1,4 @@
-package com.arabook.arabook.api.book.controller.dto.response;
+package com.arabook.arabook.api.hashtag.controller.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/arabook/arabook/common/success/category/CategorySuccessType.java
+++ b/src/main/java/com/arabook/arabook/common/success/category/CategorySuccessType.java
@@ -1,0 +1,27 @@
+package com.arabook.arabook.common.success.category;
+
+import org.springframework.http.HttpStatus;
+
+import com.arabook.arabook.common.success.common.SuccessType;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CategorySuccessType implements SuccessType {
+  // 200 OK
+  GET_CATEGORIES(HttpStatus.OK, "카테고리 조회에 성공했습니다");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public HttpStatus status() {
+    return this.status;
+  }
+
+  @Override
+  public String message() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/arabook/arabook/storage/domain/book/repository/BookCustomRepositoryImpl.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/book/repository/BookCustomRepositoryImpl.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Repository;
 
 import com.arabook.arabook.api.book.controller.dto.response.BookDetailResponse;
 import com.arabook.arabook.api.book.controller.dto.response.BookResponse;
-import com.arabook.arabook.api.book.controller.dto.response.HashTagResponse;
 import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
+import com.arabook.arabook.api.hashtag.controller.dto.response.HashTagResponse;
 import com.arabook.arabook.common.exception.book.BookException;
 import com.arabook.arabook.storage.domain.book.entity.Book;
 import com.arabook.arabook.storage.domain.book.entity.QBestSeller;

--- a/src/main/java/com/arabook/arabook/storage/domain/book/repository/BookCustomRepositoryImpl.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/book/repository/BookCustomRepositoryImpl.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Repository;
 
 import com.arabook.arabook.api.book.controller.dto.response.BookDetailResponse;
 import com.arabook.arabook.api.book.controller.dto.response.BookResponse;
-import com.arabook.arabook.api.book.controller.dto.response.CategoryResponse;
 import com.arabook.arabook.api.book.controller.dto.response.HashTagResponse;
+import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
 import com.arabook.arabook.common.exception.book.BookException;
 import com.arabook.arabook.storage.domain.book.entity.Book;
 import com.arabook.arabook.storage.domain.book.entity.QBestSeller;

--- a/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryCustomRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryCustomRepository.java
@@ -1,0 +1,9 @@
+package com.arabook.arabook.storage.domain.category.repository;
+
+import java.util.List;
+
+import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
+
+public interface CategoryCustomRepository {
+  List<CategoryResponse> findAllOrderByCategoryNameAsc();
+}

--- a/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryCustomRepositoryImpl.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryCustomRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.arabook.arabook.storage.domain.category.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.arabook.arabook.api.category.controller.dto.response.CategoryResponse;
+import com.arabook.arabook.storage.domain.category.entity.QCategory;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryCustomRepositoryImpl implements CategoryCustomRepository {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<CategoryResponse> findAllOrderByCategoryNameAsc() {
+    QCategory category = QCategory.category;
+
+    return queryFactory
+        .select(Projections.fields(CategoryResponse.class, category.categoryId, category.name))
+        .from(category)
+        .orderBy(category.name.asc())
+        .fetch();
+  }
+}

--- a/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryCustomRepositoryImpl.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryCustomRepositoryImpl.java
@@ -21,7 +21,7 @@ public class CategoryCustomRepositoryImpl implements CategoryCustomRepository {
     QCategory category = QCategory.category;
 
     return queryFactory
-        .select(Projections.fields(CategoryResponse.class, category.categoryId, category.name))
+        .select(Projections.constructor(CategoryResponse.class, category.categoryId, category.name))
         .from(category)
         .orderBy(category.name.asc())
         .fetch();

--- a/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/category/repository/CategoryRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.arabook.arabook.storage.domain.category.entity.Category;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {}
+public interface CategoryRepository
+    extends JpaRepository<Category, Long>, CategoryCustomRepository {}


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 온보딩에서 책들을 분류하는 카테고리 리스트를 조회하는 API를 구현했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- CategoryResponse, HashTagResonse를 각 도메인 controller dto로 옮겼습니다

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 조회<br>성공 | <img src = "https://github.com/user-attachments/assets/7574ba05-ad92-4476-ba87-65cc00399783" width ="700">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #41
