### PR TITLE
[Feat] #36 - 책 기록 내용 수정 API 구현

### DIFF
--- a/src/main/java/com/arabook/arabook/api/review/controller/ReviewApi.java
+++ b/src/main/java/com/arabook/arabook/api/review/controller/ReviewApi.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import com.arabook.arabook.api.review.controller.dto.request.CreateReviewRequest;
 import com.arabook.arabook.api.review.controller.dto.request.UpdateReviewRequest;
 import com.arabook.arabook.api.review.controller.dto.response.ReviewDetailResponse;
+import com.arabook.arabook.api.review.controller.dto.response.ReviewIdResponse;
 import com.arabook.arabook.api.review.controller.dto.response.ReviewsResponse;
 import com.arabook.arabook.common.response.ResponseTemplate;
 
@@ -25,7 +26,7 @@ public interface ReviewApi {
         @ApiResponse(responseCode = "404", description = "해당 책을 찾을 수 없습니다.")
       })
   @Operation(summary = "책 기록하기: 책 기록 생성 요청", description = "책 기록을 생성합니다.")
-  ResponseEntity<ResponseTemplate> createReview(CreateReviewRequest request);
+  ResponseEntity<ResponseTemplate<ReviewIdResponse>> createReview(CreateReviewRequest request);
 
   @ApiResponses(
       value = {
@@ -38,11 +39,15 @@ public interface ReviewApi {
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "200", description = "기록을 수정했습니다."),
-        @ApiResponse(responseCode = "400", description = "기록 수정 요청이 잘못되었습니다."),
+        @ApiResponse(
+            responseCode = "400",
+            description = "책 읽기 시작 날짜가 올바르지 않습니다. (책을 읽기 시작한 날짜가 다 읽은 날짜보다 늦을 경우)"),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않습니다. (넘기는 필드가 조건에 부합하지 않는 경우"),
         @ApiResponse(responseCode = "404", description = "기록을 찾을 수 없습니다.")
       })
   @Operation(summary = "책 기록하기: 책 기록 수정 요청", description = "책 기록을 수정합니다.")
-  ResponseEntity<ResponseTemplate> updateReview(UpdateReviewRequest request);
+  ResponseEntity<ResponseTemplate<ReviewIdResponse>> updateReview(
+      UpdateReviewRequest request, Long memberId);
 
   @ApiResponses(
       value = {

--- a/src/main/java/com/arabook/arabook/api/review/controller/ReviewController.java
+++ b/src/main/java/com/arabook/arabook/api/review/controller/ReviewController.java
@@ -8,12 +8,15 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.arabook.arabook.api.global.security.AuthMember;
 import com.arabook.arabook.api.review.controller.dto.request.CreateReviewRequest;
+import com.arabook.arabook.api.review.controller.dto.request.UpdateReviewRequest;
+import com.arabook.arabook.api.review.controller.dto.response.ReviewIdResponse;
 import com.arabook.arabook.api.review.service.ReviewService;
 import com.arabook.arabook.common.response.ResponseTemplate;
 
@@ -28,10 +31,18 @@ public class ReviewController {
   private static final String REVIEW_PATH = "/reviews";
 
   @PostMapping("")
-  public ResponseEntity<ResponseTemplate> createReview(
+  public ResponseEntity<ResponseTemplate<ReviewIdResponse>> createReview(
       @RequestBody @Valid final CreateReviewRequest request, @AuthMember final Long memberId) {
-    Long reviewId = reviewService.createReview(request, memberId);
-    URI uri = URI.create(REVIEW_PATH + "/" + reviewId);
-    return ResponseEntity.created(uri).body(ResponseTemplate.success(CREATE_REVIEW_SUCCESS));
+    ReviewIdResponse response = reviewService.createReview(request, memberId);
+    URI uri = URI.create(REVIEW_PATH + "/" + response.reviewId());
+    return ResponseEntity.created(uri)
+        .body(ResponseTemplate.success(CREATE_REVIEW_SUCCESS, response));
+  }
+
+  @PutMapping("")
+  ResponseEntity<ResponseTemplate<ReviewIdResponse>> updateReview(
+      @RequestBody @Valid UpdateReviewRequest request, @AuthMember final Long memberId) {
+    ReviewIdResponse response = reviewService.updateReview(request, memberId);
+    return ResponseEntity.ok().body(ResponseTemplate.success(UPDATE_REVIEW_SUCCESS, response));
   }
 }

--- a/src/main/java/com/arabook/arabook/api/review/controller/dto/response/ReviewIdResponse.java
+++ b/src/main/java/com/arabook/arabook/api/review/controller/dto/response/ReviewIdResponse.java
@@ -1,0 +1,10 @@
+package com.arabook.arabook.api.review.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "ReviewIdResponse", description = "기록 id 조회 DTO")
+public record ReviewIdResponse(@Schema(description = "기록 id", example = "1") Long reviewId) {
+  public static ReviewIdResponse of(Long reviewId) {
+    return new ReviewIdResponse(reviewId);
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/review/service/ReviewService.java
+++ b/src/main/java/com/arabook/arabook/api/review/service/ReviewService.java
@@ -1,7 +1,11 @@
 package com.arabook.arabook.api.review.service;
 
 import com.arabook.arabook.api.review.controller.dto.request.CreateReviewRequest;
+import com.arabook.arabook.api.review.controller.dto.request.UpdateReviewRequest;
+import com.arabook.arabook.api.review.controller.dto.response.ReviewIdResponse;
 
 public interface ReviewService {
-  Long createReview(CreateReviewRequest request, Long memberId);
+  ReviewIdResponse createReview(CreateReviewRequest request, Long memberId);
+
+  ReviewIdResponse updateReview(UpdateReviewRequest request, Long memberId);
 }

--- a/src/main/java/com/arabook/arabook/api/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/api/review/service/ReviewServiceImpl.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.arabook.arabook.api.review.controller.dto.request.CreateReviewRequest;
+import com.arabook.arabook.api.review.controller.dto.request.UpdateReviewRequest;
+import com.arabook.arabook.api.review.controller.dto.response.ReviewIdResponse;
 import com.arabook.arabook.storage.domain.book.entity.Book;
 import com.arabook.arabook.storage.domain.book.repository.BookRepository;
 import com.arabook.arabook.storage.domain.member.entity.Member;
@@ -22,19 +24,31 @@ public class ReviewServiceImpl implements ReviewService {
   private final ReviewRepository reviewRepository;
 
   @Override
-  public Long createReview(CreateReviewRequest request, Long memberId) {
+  @Transactional
+  public ReviewIdResponse createReview(CreateReviewRequest request, Long memberId) {
     Member member = memberRepository.findByMemberIdOrThrow(memberId);
     Book book = bookRepository.findByBookIdOrThrow(request.bookId());
     Review review =
         Review.builder()
             .reviwer(member)
             .book(book)
+            .content(request.content())
             .reviewTag(request.reviewTag())
             .readStartDate(request.readStartDate())
             .readEndDate(request.readEndDate())
             .build();
     reviewRepository.save(review);
 
-    return review.getReviewId();
+    return ReviewIdResponse.of(review.getReviewId());
+  }
+
+  @Override
+  @Transactional
+  public ReviewIdResponse updateReview(final UpdateReviewRequest request, final Long memberId) {
+    Review review =
+        reviewRepository.findByReviewIdAndReviewerIdOrThrow(request.reviewId(), memberId);
+    review.updateReview(
+        request.content(), request.reviewTag(), request.readStartDate(), request.readEndDate());
+    return ReviewIdResponse.of(review.getReviewId());
   }
 }

--- a/src/main/java/com/arabook/arabook/common/exception/review/ReviewExceptionType.java
+++ b/src/main/java/com/arabook/arabook/common/exception/review/ReviewExceptionType.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ReviewExceptionType implements ExceptionType {
   INVALID_READ_START_DATE(HttpStatus.BAD_REQUEST, "책 읽기 시작 날짜가 올바르지 않습니다."),
-  ;
+  NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "기록을 찾을 수 없습니다");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/arabook/arabook/common/success/review/ReviewSuccessType.java
+++ b/src/main/java/com/arabook/arabook/common/success/review/ReviewSuccessType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ReviewSuccessType implements SuccessType {
-  CREATE_REVIEW_SUCCESS(HttpStatus.CREATED, "기록이 생성되었습니다");
+  CREATE_REVIEW_SUCCESS(HttpStatus.CREATED, "기록이 생성되었습니다"),
+  UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "기록을 수정했습니다");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/arabook/arabook/storage/domain/review/entity/Review.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/review/entity/Review.java
@@ -44,6 +44,8 @@ public class Review extends BaseTimeEntity {
   @JoinColumn(name = "book_id")
   private Book book;
 
+  private String content;
+
   @NotNull
   @Enumerated(EnumType.STRING)
   @NotNull
@@ -57,11 +59,13 @@ public class Review extends BaseTimeEntity {
   private Review(
       Member reviwer,
       Book book,
+      String content,
       ReviewTag reviewTag,
       LocalDate readStartDate,
       LocalDate readEndDate) {
     this.reviwer = reviwer;
     this.book = book;
+    this.content = content;
     this.reviewTag = reviewTag;
     validateReadDate(readStartDate, readEndDate);
     this.readStartDate = readStartDate;
@@ -72,5 +76,14 @@ public class Review extends BaseTimeEntity {
     if (readStartDate.isAfter(readEndDate)) {
       throw new ReviewException(INVALID_READ_START_DATE);
     }
+  }
+
+  public void updateReview(
+      String content, ReviewTag reviewTag, LocalDate readStartDate, LocalDate readEndDate) {
+    validateReadDate(readStartDate, readEndDate);
+    this.content = content;
+    this.reviewTag = reviewTag;
+    this.readStartDate = readStartDate;
+    this.readEndDate = readEndDate;
   }
 }

--- a/src/main/java/com/arabook/arabook/storage/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,23 @@
 package com.arabook.arabook.storage.domain.review.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import static com.arabook.arabook.common.exception.review.ReviewExceptionType.*;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.arabook.arabook.common.exception.review.ReviewException;
 import com.arabook.arabook.storage.domain.review.entity.Review;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {}
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+  @Query("SELECT r FROM Review r WHERE r.reviewId = :reviewId AND r.reviwer.memberId = :reviewerId")
+  Optional<Review> findByReviewIdAndReviewerId(
+      @Param("reviewId") final Long reviewId, @Param("reviewerId") final Long reviewerId);
+
+  default Review findByReviewIdAndReviewerIdOrThrow(final Long reviewId, final Long reviewerId) {
+    return findByReviewIdAndReviewerId(reviewId, reviewerId)
+        .orElseThrow(() -> new ReviewException(NOT_FOUND_REVIEW));
+  }
+}


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 책 기록 내용을 수정하는 API를 구현했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- 책 기록, 책 기록 내용 수정 API 모두 ResponseBody에 reviewId를 반환하도록 변경했습니다

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 정상 요청 | <img src = "https://github.com/user-attachments/assets/0e77517d-fd57-4f46-9c2d-04ee6cd5d2f9" width ="700">|
| 사용자가 작성한 review에 대한 수정 요청이 아닐 때 | <img src = "https://github.com/user-attachments/assets/64ac2bf5-0fb6-4315-b7d4-8c8763d90092" width ="700">|
| 요청 필드가 잘못되었을 때 | <img src = "https://github.com/user-attachments/assets/24d7c193-9a82-4fc9-a4dc-bac03b74b422" width ="700">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #36
