### PR TITLE
[Feat] #51 - 소셜 로그인(카카오) API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//Webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/arabook/arabook/api/auth/controller/AuthApi.java
+++ b/src/main/java/com/arabook/arabook/api/auth/controller/AuthApi.java
@@ -1,0 +1,45 @@
+package com.arabook.arabook.api.auth.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+
+import com.arabook.arabook.api.auth.controller.dto.request.AuthRequest;
+import com.arabook.arabook.api.auth.controller.dto.response.AuthResponse;
+import com.arabook.arabook.common.response.ResponseTemplate;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "auth", description = "인증과 관련된 API")
+public interface AuthApi {
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "소셜 로그인에 성공했습니다",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            example =
+                                "{\"code\": 200, \"message\": \"온보딩을 완료했습니다.\", \"data\": {\"memberId\": 2, \"role\": \"GUEST\", \"token\": {\"accessToken\": \"accessToken\", \"refreshToken\": \"refreshToken\"}}}"))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "소셜 로그인에 실패했습니다",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            example =
+                                "{\"code\": 400, \"message\": \"올바르지 않은 소셜 로그인 요청입니다.\", \"data\": \"No Data\"}")))
+      })
+  @Operation(summary = "온보딩: 카테고리 리스트 조회", description = "카테고리를 조회합니다.")
+  ResponseEntity<ResponseTemplate<AuthResponse>> signUpOrLogin(@Valid AuthRequest request);
+}

--- a/src/main/java/com/arabook/arabook/api/auth/controller/AuthController.java
+++ b/src/main/java/com/arabook/arabook/api/auth/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.arabook.arabook.api.auth.controller;
+
+import static com.arabook.arabook.common.success.member.MemberSuccessType.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.arabook.arabook.api.auth.controller.dto.request.AuthRequest;
+import com.arabook.arabook.api.auth.controller.dto.response.AuthResponse;
+import com.arabook.arabook.api.auth.service.AuthService;
+import com.arabook.arabook.common.response.ResponseTemplate;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+  private final AuthService authService;
+
+  @PostMapping("/social-login")
+  public ResponseEntity<ResponseTemplate<AuthResponse>> signUpOrLogin(
+      @RequestBody AuthRequest request) {
+    AuthResponse response = authService.signUpOrLogin(request);
+    return ResponseEntity.ok(ResponseTemplate.success(ONBOARDING_SUCCESS, response));
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/auth/controller/dto/request/AuthRequest.java
+++ b/src/main/java/com/arabook/arabook/api/auth/controller/dto/request/AuthRequest.java
@@ -1,0 +1,13 @@
+package com.arabook.arabook.api.auth.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.arabook.arabook.storage.domain.member.entity.enums.SocialPlatformType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "AuthRequest", description = "소셜 로그인 요청 DTO")
+public record AuthRequest(
+    @Schema(description = "소셜 플랫폼", example = "KAKAO/APPLE") @NotNull
+        SocialPlatformType platformType,
+    @Schema(description = "소셜 플랫폼에서 받은 토큰", example = "TOKEN") @NotNull String socialToken) {}

--- a/src/main/java/com/arabook/arabook/api/auth/controller/dto/response/AuthResponse.java
+++ b/src/main/java/com/arabook/arabook/api/auth/controller/dto/response/AuthResponse.java
@@ -1,0 +1,11 @@
+package com.arabook.arabook.api.auth.controller.dto.response;
+
+import com.arabook.arabook.storage.domain.member.entity.enums.Role;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "AuthResponse", description = "소셜 로그인 응답 DTO")
+public record AuthResponse(
+    @Schema(description = "회원 id", example = "1") Long memberId,
+    @Schema(description = "회원 권한", example = "GUEST or MEMBER") Role role,
+    @Schema(description = "토큰 정보") IssueTokenResponse token) {}

--- a/src/main/java/com/arabook/arabook/api/auth/controller/dto/response/IssueTokenResponse.java
+++ b/src/main/java/com/arabook/arabook/api/auth/controller/dto/response/IssueTokenResponse.java
@@ -1,6 +1,11 @@
 package com.arabook.arabook.api.auth.controller.dto.response;
 
-public record IssueTokenResponse(String accessToken, String refreshToken) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "IssueTokenResponse", description = "토큰 응답 DTO")
+public record IssueTokenResponse(
+    @Schema(description = "액세스 토큰") String accessToken,
+    @Schema(description = "리프레시 토큰") String refreshToken) {
   public static IssueTokenResponse of(String accessToken, String refreshToken) {
     return new IssueTokenResponse(accessToken, refreshToken);
   }

--- a/src/main/java/com/arabook/arabook/api/auth/service/AuthService.java
+++ b/src/main/java/com/arabook/arabook/api/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.arabook.arabook.api.auth.service;
+
+import com.arabook.arabook.api.auth.controller.dto.request.AuthRequest;
+import com.arabook.arabook.api.auth.controller.dto.response.AuthResponse;
+
+public interface AuthService {
+  AuthResponse signUpOrLogin(AuthRequest request);
+  // IssueTokenResponse issueToken(IssueTokenRequest request);
+}

--- a/src/main/java/com/arabook/arabook/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/api/auth/service/AuthServiceImpl.java
@@ -1,0 +1,42 @@
+package com.arabook.arabook.api.auth.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.arabook.arabook.api.auth.controller.dto.request.AuthRequest;
+import com.arabook.arabook.api.auth.controller.dto.response.AuthResponse;
+import com.arabook.arabook.api.auth.controller.dto.response.IssueTokenResponse;
+import com.arabook.arabook.api.auth.service.vo.AuthMemberVO;
+import com.arabook.arabook.external.jwt.service.JwtService;
+import com.arabook.arabook.storage.domain.member.entity.Member;
+import com.arabook.arabook.storage.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthServiceImpl implements AuthService {
+  private final MemberRepository memberRepository;
+  private final JwtService jwtTokenService;
+  private final AuthServiceProvider authServiceProvider;
+
+  @Override
+  public AuthResponse signUpOrLogin(AuthRequest request) {
+    SocialAuthService authService = authServiceProvider.getAuthService(request.platformType());
+    AuthMemberVO authMemberVO = authService.getUserInfo(request.socialToken());
+    Member member = findOrSaveMember(authMemberVO);
+    String memberId = member.getMemberId().toString();
+    List<String> roles = List.of(member.getRole().name());
+    IssueTokenResponse issueTokenResponse = jwtTokenService.issueToken(memberId, roles);
+    return new AuthResponse(member.getMemberId(), member.getRole(), issueTokenResponse);
+  }
+
+  private Member findOrSaveMember(AuthMemberVO authMemberVO) {
+    return memberRepository
+        .findBySocialPlatformId(authMemberVO.platformId())
+        .orElseGet(() -> memberRepository.save(authMemberVO.toEntity()));
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/auth/service/AuthServiceProvider.java
+++ b/src/main/java/com/arabook/arabook/api/auth/service/AuthServiceProvider.java
@@ -1,0 +1,30 @@
+package com.arabook.arabook.api.auth.service;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.stereotype.Component;
+
+import com.arabook.arabook.external.social.service.KakaoSocialAuthService;
+import com.arabook.arabook.storage.domain.member.entity.enums.SocialPlatformType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthServiceProvider {
+  private static final ConcurrentHashMap<SocialPlatformType, SocialAuthService> authServiceMap =
+      new ConcurrentHashMap<>();
+
+  private final KakaoSocialAuthService kakaoAuthService;
+
+  @PostConstruct
+  void initialAuthServiceMap() {
+    authServiceMap.put(SocialPlatformType.KAKAO, kakaoAuthService);
+  }
+
+  public SocialAuthService getAuthService(SocialPlatformType platformType) {
+    return authServiceMap.get(platformType);
+  }
+}

--- a/src/main/java/com/arabook/arabook/api/auth/service/SocialAuthService.java
+++ b/src/main/java/com/arabook/arabook/api/auth/service/SocialAuthService.java
@@ -1,0 +1,7 @@
+package com.arabook.arabook.api.auth.service;
+
+import com.arabook.arabook.api.auth.service.vo.AuthMemberVO;
+
+public interface SocialAuthService {
+  AuthMemberVO getUserInfo(String accessToken);
+}

--- a/src/main/java/com/arabook/arabook/api/auth/service/vo/AuthMemberVO.java
+++ b/src/main/java/com/arabook/arabook/api/auth/service/vo/AuthMemberVO.java
@@ -1,0 +1,21 @@
+package com.arabook.arabook.api.auth.service.vo;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.arabook.arabook.storage.domain.member.entity.Member;
+import com.arabook.arabook.storage.domain.member.entity.enums.SocialPlatformType;
+
+public record AuthMemberVO(
+    @NotNull String platformId, @NotNull SocialPlatformType platformType, String email) {
+  public static AuthMemberVO of(String platformId, SocialPlatformType platformType) {
+    return new AuthMemberVO(platformId, platformType, null);
+  }
+
+  public static AuthMemberVO of(String platformId, SocialPlatformType platformType, String email) {
+    return new AuthMemberVO(platformId, platformType, email);
+  }
+
+  public Member toEntity() {
+    return Member.builder().socialPlatformId(platformId).socialPlatformType(platformType).build();
+  }
+}

--- a/src/main/java/com/arabook/arabook/common/exception/auth/AuthExceptionType.java
+++ b/src/main/java/com/arabook/arabook/common/exception/auth/AuthExceptionType.java
@@ -14,7 +14,9 @@ public enum AuthExceptionType implements ExceptionType {
   INVALID_TOKEN_HEADER(HttpStatus.BAD_REQUEST, "토큰 헤더가 존재하지 않습니다."),
   INVALID_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않은 토큰입니다."),
   UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "기한이 만료된 토큰입니다."),
-  INVALID_REQUEST_LOGIN(HttpStatus.BAD_REQUEST, "올바르지 않은 로그인 요청입니다");
+  INVALID_REQUEST_LOGIN(HttpStatus.BAD_REQUEST, "올바르지 않은 로그인 요청입니다"),
+  INVALID_REQUEST_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, "올바르지 않은 소셜 로그인 요청입니다"),
+  ;
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/arabook/arabook/external/social/service/KakaoSocialAuthService.java
+++ b/src/main/java/com/arabook/arabook/external/social/service/KakaoSocialAuthService.java
@@ -1,0 +1,47 @@
+package com.arabook.arabook.external.social.service;
+
+import static com.arabook.arabook.common.exception.auth.AuthExceptionType.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.arabook.arabook.api.auth.service.SocialAuthService;
+import com.arabook.arabook.api.auth.service.vo.AuthMemberVO;
+import com.arabook.arabook.common.exception.auth.AuthException;
+import com.arabook.arabook.external.social.service.dto.KakaoUserInfoResponse;
+import com.arabook.arabook.storage.domain.member.entity.enums.SocialPlatformType;
+
+import reactor.core.publisher.Mono;
+
+@Service
+public class KakaoSocialAuthService implements SocialAuthService {
+  private static final String KAKAO_API_USER_URL_HOST = "https://kapi.kakao.com/";
+  private static final String KAKAO_API_USER_INFO_PATH = "v2/user/me";
+  private static final String KAKAO_AUTHORIZATION_TYPE = "Bearer ";
+  private static final String KAKAO_CONTENT_TYPE =
+      "application/x-www-form-urlencoded;charset=utf-8";
+  private static final SocialPlatformType KAKAO_PLATFORM_TYPE = SocialPlatformType.KAKAO;
+
+  @Override
+  public AuthMemberVO getUserInfo(String accessToken) {
+    KakaoUserInfoResponse response =
+        WebClient.create(KAKAO_API_USER_URL_HOST)
+            .get()
+            .uri(
+                uriBuilder -> uriBuilder.scheme("https").path(KAKAO_API_USER_INFO_PATH).build(true))
+            .header(HttpHeaders.AUTHORIZATION, KAKAO_AUTHORIZATION_TYPE + accessToken)
+            .header(HttpHeaders.CONTENT_TYPE, KAKAO_CONTENT_TYPE)
+            .retrieve()
+            .onStatus(
+                HttpStatusCode::is4xxClientError,
+                clientResponse -> Mono.error(new AuthException(INVALID_REQUEST_SOCIAL_LOGIN)))
+            .bodyToMono(KakaoUserInfoResponse.class)
+            .block();
+
+    String platformId = response.id().toString();
+
+    return AuthMemberVO.of(platformId, KAKAO_PLATFORM_TYPE);
+  }
+}

--- a/src/main/java/com/arabook/arabook/external/social/service/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/arabook/arabook/external/social/service/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,8 @@
+package com.arabook.arabook.external.social.service.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponse(@NotNull Long id) {}

--- a/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
@@ -37,8 +37,6 @@ public class Member extends BaseTimeEntity {
   @Column(unique = true)
   private String socialPlatformId;
 
-  @NotNull
-  @Column(unique = true)
   private String email;
 
   @NotNull

--- a/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
@@ -39,6 +39,8 @@ public class Member extends BaseTimeEntity {
 
   private String email;
 
+  private String nickname;
+
   @NotNull
   @Enumerated(EnumType.STRING)
   private Gender gender;

--- a/src/main/java/com/arabook/arabook/storage/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/member/repository/MemberRepository.java
@@ -15,4 +15,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   default Member findByMemberIdOrThrow(final Long memberId) {
     return findByMemberId(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
   }
+
+  Optional<Member> findBySocialPlatformId(final String socialPlatformId);
 }


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 카카오 소셜 로그인을 구현했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- AuthProvider를 통해 요청에 담겨오는 SocialPlatformType에 따라 로그인 과정을 다르게 처리할 수 있도록 구현했습니다

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로그인 성공 | <img src = "https://github.com/user-attachments/assets/eb3cbc8b-ec21-4258-9cbe-d4ab55b9e416" width ="700">|
| 로그인 실패 | <img src = "https://github.com/user-attachments/assets/490891b2-4762-424f-a820-db8b57955b0e" width ="700">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #51
