### PR TITLE
[Feat] #57 - 온보딩 API 변경(닉네임, 태어난 연도를 받도록 변경)

### DIFF
--- a/src/main/java/com/arabook/arabook/api/member/controller/MemberApi.java
+++ b/src/main/java/com/arabook/arabook/api/member/controller/MemberApi.java
@@ -17,7 +17,7 @@ public interface MemberApi {
   @ApiResponses(
       value = {
         @ApiResponse(
-            responseCode = "204",
+            responseCode = "200",
             description = "온보딩을 완료했습니다.",
             content =
                 @Content(
@@ -25,7 +25,7 @@ public interface MemberApi {
                     schema =
                         @Schema(
                             example =
-                                "{ \"code\": 204, \"message\": \"온보딩을 완료했습니다.\", \"data\": \"No Data\" }"))),
+                                "{ \"code\": 200, \"message\": \"온보딩을 완료했습니다.\", \"data\": \"No Data\" }"))),
         @ApiResponse(
             responseCode = "400",
             description = "유효한 카테고리를 찾을 수 없습니다",

--- a/src/main/java/com/arabook/arabook/api/member/controller/dto/request/MemberOnboardingRequest.java
+++ b/src/main/java/com/arabook/arabook/api/member/controller/dto/request/MemberOnboardingRequest.java
@@ -10,7 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "MemberOnboardingRequest", description = "회원 온보딩 요청 DTO")
 public record MemberOnboardingRequest(
+    @Schema(description = "회원의 별명", example = "으나") @NotNull String nickname,
     @Schema(description = "성별 (MAN, WOMAN, UNKNOWN", example = "WOMAN") @NotNull Gender gender,
-    @Schema(description = "나이", example = "21") int age,
-    @Schema(description = "서버로부터 조회한 category id 리스트", example = "[1,2,3]") @NotNull
-        List<Long> interestCategoryIds) {}
+    @Schema(description = "태어난 년도", example = "2001, 선택하지 않은 경우에는 null") String birthYear,
+    @Schema(description = "서버로부터 조회한 sub category id 리스트", example = "[1,2,3]") @NotNull
+        List<Long> interestSubCategoryIds) {}

--- a/src/main/java/com/arabook/arabook/api/member/controller/dto/request/MemberOnboardingRequest.java
+++ b/src/main/java/com/arabook/arabook/api/member/controller/dto/request/MemberOnboardingRequest.java
@@ -12,6 +12,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MemberOnboardingRequest(
     @Schema(description = "회원의 별명", example = "으나") @NotNull String nickname,
     @Schema(description = "성별 (MAN, WOMAN, UNKNOWN", example = "WOMAN") @NotNull Gender gender,
-    @Schema(description = "태어난 년도", example = "2001, 선택하지 않은 경우에는 null") String birthYear,
+    @Schema(description = "태어난 년도, 선택하지 않은 경우에는 null", example = "2001") String birthYear,
     @Schema(description = "서버로부터 조회한 sub category id 리스트", example = "[1,2,3]") @NotNull
         List<Long> interestSubCategoryIds) {}

--- a/src/main/java/com/arabook/arabook/api/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/api/member/service/MemberServiceImpl.java
@@ -20,7 +20,8 @@ public class MemberServiceImpl implements MemberService {
   @Transactional
   public void onboarding(final MemberOnboardingRequest request, final Long memberId) {
     Member member = memberRepository.findByMemberIdOrThrow(memberId);
-    member.updateOnboardingInfo(request.gender(), request.age());
-    memberCategorySelectionSerivce.selectSubCategories(member, request.interestCategoryIds());
+    int age = member.calculateAge(request.birthYear());
+    member.updateOnboardingInfo(request.nickname(), request.gender(), age);
+    memberCategorySelectionSerivce.selectSubCategories(member, request.interestSubCategoryIds());
   }
 }

--- a/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
+++ b/src/main/java/com/arabook/arabook/storage/domain/member/entity/Member.java
@@ -1,5 +1,7 @@
 package com.arabook.arabook.storage.domain.member.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -61,8 +63,16 @@ public class Member extends BaseTimeEntity {
     this.role = Role.GUEST;
   }
 
-  public void updateOnboardingInfo(final Gender gender, final int age) {
+  public void updateOnboardingInfo(final String nickname, final Gender gender, final int age) {
+    this.nickname = nickname;
     this.gender = gender;
     this.age = age;
+  }
+
+  public int calculateAge(final String birthYear) {
+    if (birthYear == null) {
+      return 999;
+    }
+    return LocalDateTime.now().getYear() - Integer.parseInt(birthYear);
   }
 }


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 온보딩 API를 변경했습니다
  - 나이 대신 태어난 연도를 입력받도록 변경했습니다
  - 닉네임을 입력받도록 필드를 추가했습니다 

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- 204 응답코드에서 200으로 수정했습니다

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 모든 필드가 있는 경우 | <img src = "https://github.com/user-attachments/assets/22b653b9-3f1b-4682-b187-b761fd1851c9" width ="500">|
| 태어난 연도가 없는 경우 | <img src = "https://github.com/user-attachments/assets/f4a49ec8-d628-4669-acba-3c47e285f99e" width ="500">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #57
