### PR TITLE
[Fix] #74 - ChronoUnit.DAYS.between을 사용하여 계산하도록 변경

### DIFF
--- a/src/main/java/com/arabook/arabook/member/entity/Member.java
+++ b/src/main/java/com/arabook/arabook/member/entity/Member.java
@@ -67,6 +67,7 @@ public class Member extends BaseTimeEntity {
     this.nickname = nickname;
     this.gender = gender;
     this.age = age;
+    this.role = Role.USER;
   }
 
   public int calculateAge(final String birthYear) {

--- a/src/main/java/com/arabook/arabook/review/controller/dto/response/ReviewResponse.java
+++ b/src/main/java/com/arabook/arabook/review/controller/dto/response/ReviewResponse.java
@@ -1,7 +1,7 @@
 package com.arabook.arabook.review.controller.dto.response;
 
 import java.time.LocalDate;
-import java.time.Period;
+import java.time.temporal.ChronoUnit;
 
 import com.arabook.arabook.review.entity.enums.ReviewTag;
 
@@ -41,6 +41,6 @@ public record ReviewResponse(
   }
 
   private static int getDayDiff(LocalDate start, LocalDate end) {
-    return Period.between(start, end).getDays();
+    return (int) ChronoUnit.DAYS.between(start, end);
   }
 }


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- Period는 연도, 월, 일 차이를 각각 반환하는 데 사용되지만, 두 날짜 간의 전체 일 차이를 계산하는 데 적합하지 않다고하여 ChronoUnit.DAYS.between을 사용하도록 변경했습니다


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #74
