### PR TITLE
[Fix] #78 - :member 파라미터 인식 오류 및 ai 추천도서 삭제 로직 구현

### DIFF
--- a/src/main/java/com/arabook/arabook/member/repository/AIRecommendationRepository.java
+++ b/src/main/java/com/arabook/arabook/member/repository/AIRecommendationRepository.java
@@ -1,0 +1,14 @@
+package com.arabook.arabook.member.repository;
+
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.*;
+import org.springframework.transaction.annotation.*;
+
+import com.arabook.arabook.member.entity.*;
+
+public interface AIRecommendationRepository extends JpaRepository<AIRecommendation, Long> {
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @Query("delete from AIRecommendation ar where ar.member = :member")
+  void deleteByMember(@Param("member") Member member);
+}

--- a/src/main/java/com/arabook/arabook/member/repository/MemberSubCategorySelectionRepository.java
+++ b/src/main/java/com/arabook/arabook/member/repository/MemberSubCategorySelectionRepository.java
@@ -14,6 +14,6 @@ public interface MemberSubCategorySelectionRepository
 
   @Modifying(clearAutomatically = true)
   @Transactional
-  @Query("delete from MemberSubCategorySelection mss where mss.member =: member")
+  @Query("delete from MemberSubCategorySelection mss where mss.member = :member")
   void deleteByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/arabook/arabook/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/arabook/arabook/member/service/MemberServiceImpl.java
@@ -20,6 +20,7 @@ public class MemberServiceImpl implements MemberService {
   private final ReviewRepository reviewRepository;
   private final MemberSubCategorySelectionRepository memberSubCategorySelectionRepository;
   private final MemberSubCategorySelectionService memberCategorySelectionService;
+  private final AIRecommendationRepository aiRecommendationRepository;
 
   @Override
   @Transactional
@@ -36,6 +37,7 @@ public class MemberServiceImpl implements MemberService {
     Member member = memberRepository.findByMemberIdOrThrow(memberId);
     memberSubCategorySelectionRepository.deleteByMember(member);
     reviewRepository.deleteByReviewer(member);
+    aiRecommendationRepository.deleteByMember(member);
     memberRepository.delete(member);
   }
 }

--- a/src/main/java/com/arabook/arabook/review/repository/ReviewRepository.java
+++ b/src/main/java/com/arabook/arabook/review/repository/ReviewRepository.java
@@ -25,8 +25,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewCus
 
   @Modifying(clearAutomatically = true)
   @Transactional
-  @Query("delete from Review r where r.reviewer =: reviewer")
+  @Query("delete from Review r where r.reviewer = :reviewer")
   void deleteByReviewer(@Param("reviewer") Member reviewer);
-
-  void deleteAllByReviewer(final Member member);
 }


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- :member 파라미터에서 member 필드 앞에 공백이 있어 콜론이 분리되어 있었습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- 이전 Pr 테스트 시 제 계정에 ai 추천도서가 없어서 로직을 누락했습니다

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 회원탈퇴 | <img src = "https://github.com/user-attachments/assets/a9b4942c-76f8-4b2f-8d77-6cc2c08514d5" width ="500">|



## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #78
